### PR TITLE
fix: correct command parsing logic

### DIFF
--- a/script.js
+++ b/script.js
@@ -13,14 +13,19 @@ document.addEventListener('DOMContentLoaded', () => {
             terminal.clear();
             return '';
         },
-        'cat mark_driscoll_resume.pdf': () => "Here's a link to my resume: [mark_driscoll_resume.pdf](./mark_driscoll_resume.pdf)"
+        cat: (args) => {
+            if (args[0] === 'mark_driscoll_resume.pdf') {
+                return "Here's a link to my resume: [mark_driscoll_resume.pdf](./mark_driscoll_resume.pdf)";
+            }
+            return `File not found: ${args.join(' ')}`;
+        }
     };
 
     // Function to process commands
     function processCommand(input) {
-        const command = input.trim();
+        const [command, ...args] = input.trim().split(/\s+/);
         if (commands[command]) {
-            return commands[command]();
+            return commands[command](args);
         } else {
             return `Command not found: ${command}`;
         }


### PR DESCRIPTION
## Summary
- handle `cat` command generically
- split user input into command and arguments

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68527e4de36c833296e3147431699ad5