### PR TITLE
Add Jest tests for command processing

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -31,6 +31,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 20
+      - name: Install dependencies
+        run: npm ci
+      - name: Run tests
+        run: npm test
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Upload artifact

--- a/__tests__/script.test.js
+++ b/__tests__/script.test.js
@@ -1,0 +1,14 @@
+const { processCommand } = require('../script');
+
+describe('processCommand', () => {
+  test('help command outputs list', () => {
+    expect(processCommand('help')).toBe('Available commands: help, cat, resume, clear');
+  });
+
+  test('clear command clears terminal', () => {
+    const terminal = { clear: jest.fn() };
+    const result = processCommand('clear', { terminal });
+    expect(terminal.clear).toHaveBeenCalled();
+    expect(result).toBe('');
+  });
+});

--- a/package.json
+++ b/package.json
@@ -5,5 +5,11 @@
     "node-pty": "^1.0.0",
     "socket.io": "^4.8.1",
     "xterm": "^5.3.0"
+  },
+  "devDependencies": {
+    "jest": "^29.6.1"
+  },
+  "scripts": {
+    "test": "jest"
   }
 }

--- a/script.js
+++ b/script.js
@@ -1,71 +1,83 @@
-document.addEventListener('DOMContentLoaded', () => {
-    // Initialize the terminal
-    const terminal = new Terminal();
-    terminal.open(document.getElementById('xterm-container'));
-    
-    // Add some initial logging to check script execution
-    console.log('Terminal initialized and opened.');
-
-    // Commands dictionary
-    // Currently supported: help, clear, cat for viewing files, and resume
-    const commands = {
-        help: () => "Available commands: help, cat, resume, clear",
-        clear: () => {
-            terminal.clear();
-            return '';
-        },
-        // The cat command only displays a not-found message since
-        // no files are currently bundled with the site
-        cat: (args) => {
-            return `File not found: ${args.join(' ')}`;
-        },
-        // Display an online resume link
-        resume: () => {
-            return "Here's a link to my resume: https://www.self.so/mark-driscoll-was-here";
+// Commands dictionary. Commands may use the optional context object which can
+// contain a `terminal` instance for commands that need direct access to the
+// xterm API (e.g. `clear`).
+const commands = {
+    help: () => "Available commands: help, cat, resume, clear",
+    clear: (_args, ctx) => {
+        if (ctx && ctx.terminal) {
+            ctx.terminal.clear();
         }
-    };
-
-    // Function to process commands
-    function processCommand(input) {
-        const [command, ...args] = input.trim().split(/\s+/);
-        if (commands[command]) {
-            return commands[command](args);
-        } else {
-            return `Command not found: ${command}`;
-        }
+        return '';
+    },
+    // The cat command only displays a not-found message since no files are
+    // currently bundled with the site
+    cat: (args) => {
+        return `File not found: ${args.join(' ')}`;
+    },
+    // Display an online resume link
+    resume: () => {
+        return "Here's a link to my resume: https://www.self.so/mark-driscoll-was-here";
     }
+};
 
-    // Initialize the prompt
-    terminal.write('> ');
+// Function to process commands. The optional `ctx` parameter allows passing the
+// terminal instance when running in the browser.
+function processCommand(input, ctx = {}) {
+    const [command, ...args] = input.trim().split(/\s+/);
+    if (commands[command]) {
+        return commands[command](args, ctx);
+    } else {
+        return `Command not found: ${command}`;
+    }
+}
 
-    let inputBuffer = '';
+// When running in the browser attach the terminal behaviour.
+if (typeof document !== 'undefined') {
+    document.addEventListener('DOMContentLoaded', () => {
+        // Initialize the terminal
+        const terminal = new Terminal();
+        terminal.open(document.getElementById('xterm-container'));
 
-    // Listen for terminal input
-    terminal.onData((data) => {
-        // Log input data for debugging
-        console.log('Received input:', data);
-        
-        // Handle Enter key (ASCII code 13)
-        if (data.charCodeAt(0) === 13) {
-            terminal.write('\r\n');
-            const outputText = processCommand(inputBuffer);
-            if (outputText) {
-                terminal.write(`${outputText}\r\n`);
+        // Add some initial logging to check script execution
+        console.log('Terminal initialized and opened.');
+
+        // Initialize the prompt
+        terminal.write('> ');
+
+        let inputBuffer = '';
+
+        // Listen for terminal input
+        terminal.onData((data) => {
+            // Log input data for debugging
+            console.log('Received input:', data);
+
+            // Handle Enter key (ASCII code 13)
+            if (data.charCodeAt(0) === 13) {
+                terminal.write('\r\n');
+                const outputText = processCommand(inputBuffer, { terminal });
+                if (outputText) {
+                    terminal.write(`${outputText}\r\n`);
+                }
+                inputBuffer = ''; // Clear input buffer
+                terminal.write('> '); // Display a new prompt
+            } else if (data.charCodeAt(0) === 127) { // Handle Backspace key
+                if (inputBuffer.length > 0) {
+                    inputBuffer = inputBuffer.slice(0, -1);
+                    terminal.write('\b \b');
+                }
+            } else {
+                inputBuffer += data;
+                terminal.write(data);
             }
-            inputBuffer = ''; // Clear input buffer
-            terminal.write('> '); // Display a new prompt
-        } else if (data.charCodeAt(0) === 127) { // Handle Backspace key
-            if (inputBuffer.length > 0) {
-                inputBuffer = inputBuffer.slice(0, -1);
-                terminal.write('\b \b');
-            }
-        } else {
-            inputBuffer += data;
-            terminal.write(data);
-        }
+        });
+
+        // Ensure the terminal is focused
+        terminal.focus();
     });
+}
 
-    // Ensure the terminal is focused
-    terminal.focus();
-});
+// Export for testing in Node environments
+if (typeof module !== 'undefined') {
+    module.exports = { processCommand };
+}
 


### PR DESCRIPTION
## Summary
- add `jest` as a dev dependency and npm test script
- export `processCommand` from `script.js`
- test `help` and `clear` commands
- run tests in GitHub Actions before deploying

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852839336f88332bdc6c4ba2b6a86a6